### PR TITLE
Fix cors error

### DIFF
--- a/AIC21_Backend/settings/development.py
+++ b/AIC21_Backend/settings/development.py
@@ -175,3 +175,10 @@ EMAIL_BACKEND = config('EMAIL_BACKEND')
 DOMAIN = config('DOMAIN', 'localhost:8000')
 
 AUTH_USER_MODEL = 'accounts.User'
+
+CORS_ORIGIN_ALLOW_ALL = False
+
+CORS_ORIGIN_WHITELIST = (
+    'stg.aichallenge.ir',
+    'aichallenge.ir',
+)


### PR DESCRIPTION
Fix cors error by adding
frontend domains to CORS_ORIGIN_WHITELIST
in django settings development.py file.